### PR TITLE
Fix error on editing content rules.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,5 +1,9 @@
 Changelog
 =========
+10.6.dev0 - (unreleased)
+------------------------
+* Bug fix: error on editing content rules.
+  [GhitaB]
 
 10.5 - (2017-12-20)
 -------------------

--- a/eea/rdfmarshaller/licenses/viewlets.py
+++ b/eea/rdfmarshaller/licenses/viewlets.py
@@ -124,7 +124,7 @@ class LicenseViewlet(ViewletBase):
         ser = marshaller.marshall(self.context, endLevel=1)
 
         if not ser:
-            return
+            return ""
 
         store = marshaller.store
 


### PR DESCRIPTION
Prevent viewlet.render() to return None to solve error:
  File "/plone/buildout-cache/eggs/plone.app.viewletmanager-2.0.9-py2.7.egg/plone/app/viewletmanager/manager.py", line 120, in render
   return u"\n".join(html)
TypeError: sequence item 1: expected string or Unicode, NoneType found